### PR TITLE
Update Questionnaire fhirContext role to "http://ns.electronichealth.net.au/smart/r…

### DIFF
--- a/input/pagecontent/smart-health-check-integration.md
+++ b/input/pagecontent/smart-health-check-integration.md
@@ -111,7 +111,7 @@ The SHCA has the following launch context requirements:
 | sub	             | required	 | Unique identifier of the user as known by the PMS authorization service.                                                                                                                                                                       |
 | preferred_username | optional  | Username used to login to PMS.                                                                                                                                                                                                                 |
 | fhirUser	         | required	 | Current user identifier used to retrieve the user’s Practitioner resource via the FHIR API.                                                                                                                                                    |
-| fhirContext        | required  | The Health Check Questionnare context to be launched <br/> `[{ "canonical": " http://www.health.gov.au/assessments/mbs/715", "role": "https://smartforms.csiro.au/smart/role/questionnaire-to-display", "type": "Questionnaire" }] ` |
+| fhirContext        | required  | The Health Check Questionnare context to be launched <br/> `[{ "role": "http://ns.electronichealth.net.au/smart/role/new", "type": "Questionnaire", "canonical": " http://www.health.gov.au/assessments/mbs/715" }]` |
 
 ##### Authorization Request
 SHCA will request the following access scopes in the authorization request `scope` parameter:

--- a/input/pagecontent/smart-health-check-integration.md
+++ b/input/pagecontent/smart-health-check-integration.md
@@ -111,7 +111,7 @@ The SHCA has the following launch context requirements:
 | sub	             | required	 | Unique identifier of the user as known by the PMS authorization service.                                                                                                                                                                       |
 | preferred_username | optional  | Username used to login to PMS.                                                                                                                                                                                                                 |
 | fhirUser	         | required	 | Current user identifier used to retrieve the user’s Practitioner resource via the FHIR API.                                                                                                                                                    |
-| fhirContext        | required  | The Health Check Questionnare context to be launched <br/> `[{ "role": "http://ns.electronichealth.net.au/smart/role/new", "type": "Questionnaire", "canonical": " http://www.health.gov.au/assessments/mbs/715" }]` |
+| fhirContext        | required  | The Health Check Questionnaire context to be launched <br/> `[{ "role": "http://ns.electronichealth.net.au/smart/role/new", "type": "Questionnaire", "canonical": " http://www.health.gov.au/assessments/mbs/715" }]` |
 
 ##### Authorization Request
 SHCA will request the following access scopes in the authorization request `scope` parameter:


### PR DESCRIPTION
Update Questionnaire fhirContext role to "http://ns.electronichealth.net.au/smart/role/new".

Adopted ADHA's role from https://confluence.hl7.org/spaces/FHIRI/pages/202409650/fhirContext+Role+Registry.

See https://github.com/aehrc/smart-forms/issues/1331 for more details.