### PR TITLE
Prepop referenced meds

### DIFF
--- a/fsh-generated/resources/Questionnaire-RegularMedications.json
+++ b/fsh-generated/resources/Questionnaire-RegularMedications.json
@@ -109,7 +109,7 @@
                   "valueExpression": {
                     "name": "MedicationStatementRepeat",
                     "language": "text/fhirpath",
-                    "expression": "%MedicationStatement.entry.resource"
+                    "expression": "%MedicationStatement.entry.resource.where(resourceType = 'MedicationStatement')"
                   }
                 },
                 {
@@ -167,7 +167,7 @@
                       "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
                       "valueExpression": {
                         "language": "text/fhirpath",
-                        "expression": "%MedicationStatementRepeat.medication.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first())"
+                        "expression": "iif(%MedicationStatementRepeat.medicationReference.reference.replace('#', '') in %medicationsFromContained.id, %medicationsFromContained.where(id = %MedicationStatementRepeat.medicationReference.reference.replace('#', '')).code.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first()), iif(%MedicationStatementRepeat.medicationReference.reference.replace('Medication/', '') in %medicationsFromRef.id , %medicationsFromRef.where(id = %MedicationStatementRepeat.medicationReference.reference.replace('Medication/', '')).code.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first()) ,%MedicationStatementRepeat.medication.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first())))"
                       }
                     }
                   ],
@@ -937,7 +937,23 @@
       "valueExpression": {
         "name": "MedicationStatement",
         "language": "application/x-fhir-query",
-        "expression": "MedicationStatement?patient={{%patient.id}}&status=active"
+        "expression": "MedicationStatement?patient={{%patient.id}}&status=active&_include=MedicationStatement:medication"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "medicationsFromContained",
+        "language": "text/fhirpath",
+        "expression": "%MedicationStatement.entry.resource.contained.where(resourceType = 'Medication' and id in %MedicationStatement.entry.resource.medicationReference.select(reference.replace('#', '')))"
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/variable",
+      "valueExpression": {
+        "name": "medicationsFromRef",
+        "language": "text/fhirpath",
+        "expression": "%MedicationStatement.entry.resource.where(resourceType = 'Medication' and id in %MedicationStatement.entry.resource.medicationReference.select(reference.replace('Medication/', '')))"
       }
     },
     {

--- a/input/fsh/715-Assessment-RegularMedications.fsh
+++ b/input/fsh/715-Assessment-RegularMedications.fsh
@@ -43,7 +43,17 @@ Description: "Regular Medications sub-questionnaire for Aboriginal and Torres St
 * extension[+].url = "http://hl7.org/fhir/StructureDefinition/variable"
 * extension[=].valueExpression.name = "MedicationStatement"
 * extension[=].valueExpression.language = #application/x-fhir-query
-* extension[=].valueExpression.expression = "MedicationStatement?patient={{%patient.id}}&status=active"
+* extension[=].valueExpression.expression = "MedicationStatement?patient={{%patient.id}}&status=active&_include=MedicationStatement:medication"
+
+* extension[+].url = "http://hl7.org/fhir/StructureDefinition/variable"
+* extension[=].valueExpression.name = "medicationsFromContained"
+* extension[=].valueExpression.language = #text/fhirpath
+* extension[=].valueExpression.expression = "%MedicationStatement.entry.resource.contained.where(resourceType = 'Medication' and id in %MedicationStatement.entry.resource.medicationReference.select(reference.replace('#', '')))"
+
+* extension[+].url = "http://hl7.org/fhir/StructureDefinition/variable"
+* extension[=].valueExpression.name = "medicationsFromRef"
+* extension[=].valueExpression.language = #text/fhirpath
+* extension[=].valueExpression.expression = "%MedicationStatement.entry.resource.where(resourceType = 'Medication' and id in %MedicationStatement.entry.resource.medicationReference.select(reference.replace('Medication/', '')))"
 
 * extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-assembleContext"
 * extension[=].valueString = "age"
@@ -110,7 +120,7 @@ Description: "Regular Medications sub-questionnaire for Aboriginal and Torres St
 // Current medications
 * item.item[=].item[0].extension[sdc-questionnaire-itemPopulationContext][+].valueExpression[+].name = "MedicationStatementRepeat"
 * item.item[=].item[0].extension[sdc-questionnaire-itemPopulationContext][=].valueExpression[=].language = #text/fhirpath
-* item.item[=].item[0].extension[sdc-questionnaire-itemPopulationContext][=].valueExpression[=].expression = "%MedicationStatement.entry.resource"
+* item.item[=].item[0].extension[sdc-questionnaire-itemPopulationContext][=].valueExpression[=].expression = "%MedicationStatement.entry.resource.where(resourceType = 'MedicationStatement')"
 * item.item[=].item[=].extension[TemplateExtractExtensionExtended][+].extension[template][+].valueReference = Reference(MedicationStatementPatchTemplate)
 * item.item[=].item[=].extension[TemplateExtractExtensionExtended][=].extension[resourceId][+].valueString = "item.where(linkId='medicationStatementId').answer.value"
 * item.item[=].item[=].extension[TemplateExtractExtensionExtended][=].extension[type][+].valueCode = #MedicationStatement
@@ -131,7 +141,7 @@ Description: "Regular Medications sub-questionnaire for Aboriginal and Torres St
 */
 * item.item[=].item[=].item[=].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
 * item.item[=].item[=].item[=].extension[=].valueExpression[+].language = #text/fhirpath
-* item.item[=].item[=].item[=].extension[=].valueExpression[=].expression = "%MedicationStatementRepeat.medication.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first())"
+* item.item[=].item[=].item[=].extension[=].valueExpression[=].expression = "iif(%MedicationStatementRepeat.medicationReference.reference.replace('#', '') in %medicationsFromContained.id, %medicationsFromContained.where(id = %MedicationStatementRepeat.medicationReference.reference.replace('#', '')).code.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first()), iif(%MedicationStatementRepeat.medicationReference.reference.replace('Medication/', '') in %medicationsFromRef.id , %medicationsFromRef.where(id = %MedicationStatementRepeat.medicationReference.reference.replace('Medication/', '')).code.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first()) ,%MedicationStatementRepeat.medication.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first())))"
 * item.item[=].item[=].item[=].linkId = "regularmedications-summary-current-medication"
 * item.item[=].item[=].item[=].text = "Medication"
 * item.item[=].item[=].item[=].type = #open-choice

--- a/input/resources/Questionnaire-AboriginalTorresStraitIslanderHealthCheck-assembled.json
+++ b/input/resources/Questionnaire-AboriginalTorresStraitIslanderHealthCheck-assembled.json
@@ -3414,7 +3414,7 @@
                     "valueExpression": {
                         "name": "MedicationStatement",
                         "language": "application/x-fhir-query",
-                        "expression": "MedicationStatement?patient={{%patient.id}}&status=active"
+                        "expression": "MedicationStatement?patient={{%patient.id}}&status=active&_include=MedicationStatement:medication"
                     }
                 },
                 {
@@ -3488,6 +3488,22 @@
                         "language": "application/x-fhir-query",
                         "expression": "Observation?code=9843-4&_count=1&_sort=-date&patient={{%patient.id}}"
                     }
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                  "valueExpression": {
+                    "name": "medicationsFromContained",
+                    "language": "text/fhirpath",
+                    "expression": "%MedicationStatement.entry.resource.contained.where(resourceType = 'Medication' and id in %MedicationStatement.entry.resource.medicationReference.select(reference.replace('#', '')))"
+                  }
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/variable",
+                  "valueExpression": {
+                    "name": "medicationsFromRef",
+                    "language": "text/fhirpath",
+                    "expression": "%MedicationStatement.entry.resource.where(resourceType = 'Medication' and id in %MedicationStatement.entry.resource.medicationReference.select(reference.replace('Medication/', '')))"
+                  }
                 },
                 {
                     "url": "http://hl7.org/fhir/StructureDefinition/variable",
@@ -6323,7 +6339,7 @@
                                             "valueExpression": {
                                                 "name": "MedicationStatementRepeat",
                                                 "language": "text/fhirpath",
-                                                "expression": "%MedicationStatement.entry.resource"
+                                                "expression": "%MedicationStatement.entry.resource.where(resourceType = 'MedicationStatement')"
                                             }
                                         },
                                         {
@@ -6381,11 +6397,11 @@
                                                     }
                                                 },
                                                 {
-                                                    "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
-                                                    "valueExpression": {
-                                                        "language": "text/fhirpath",
-                                                        "expression": "%MedicationStatementRepeat.medication.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first())"
-                                                    }
+                                                  "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression",
+                                                  "valueExpression": {
+                                                    "language": "text/fhirpath",
+                                                    "expression": "iif(%MedicationStatementRepeat.medicationReference.reference.replace('#', '') in %medicationsFromContained.id, %medicationsFromContained.where(id = %MedicationStatementRepeat.medicationReference.reference.replace('#', '')).code.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first()), iif(%MedicationStatementRepeat.medicationReference.reference.replace('Medication/', '') in %medicationsFromRef.id , %medicationsFromRef.where(id = %MedicationStatementRepeat.medicationReference.reference.replace('Medication/', '')).code.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first()) ,%MedicationStatementRepeat.medication.select((coding.where(system='http://snomed.info/sct') | coding.where(system!='http://snomed.info/sct').first() | text ).first())))"
+                                                  }
                                                 }
                                             ],
                                             "linkId": "regularmedications-summary-current-medication",


### PR DESCRIPTION
Add support for contained and externally referenced Medications when pre-populating the Regular medications section.

#### New capability:
- Supports resolving medications referenced by contained resources.
- Handles Medications included in the bundle via `_include=MedicationStatement:medication`

#### Changes made:
- Added `_include=MedicationStatement:medication` to MedicationStatement x-fhir-query.
- Added `medicationsFromContained` and `medicationsFromRef` variables containing an array of **Medication** resources, contained and externally referenced respectively.
- Added `.where(resourceType = 'MedicationStatement')` to MedicationStatementRepeat to ensure only **MedicationStatement** resources shows up in the form.
- Change initialExpression logic of linkId `regularmedications-summary-current-medication` to now access `Medication.code` from contained and externally referenced meds.

#### Notes:
@liambarnes can you check FSH if there's any mistakes, not too familiar with the syntax...



