### PR TITLE
Add item.text hidden extension to hide rendering of item text labels (No FSH)

### DIFF
--- a/fsh-generated/resources/Questionnaire-AbsoluteCVDRiskCalculation.json
+++ b/fsh-generated/resources/Questionnaire-AbsoluteCVDRiskCalculation.json
@@ -439,6 +439,15 @@
                 }
               ],
               "linkId": "fe9feec6-593a-4106-8a7d-f9965a632ea2",
+              "text": "Observation values",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": false
             },

--- a/fsh-generated/resources/Questionnaire-AllergiesAdverseReactions.json
+++ b/fsh-generated/resources/Questionnaire-AllergiesAdverseReactions.json
@@ -252,6 +252,15 @@
                 }
               ],
               "linkId": "allergysummary",
+              "text": "Adverse reaction risk summary",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": true
             },
@@ -270,6 +279,15 @@
                 }
               ],
               "linkId": "allergynew",
+              "text": "New adverse reaction risks",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": true,
               "item": [

--- a/fsh-generated/resources/Questionnaire-Examination.json
+++ b/fsh-generated/resources/Questionnaire-Examination.json
@@ -926,6 +926,15 @@
             }
           ],
           "linkId": "3639c586-9576-48d3-a52b-e91fd2138581",
+          "text": "Blood pressure",
+          "_text": {
+            "extension": [
+              {
+                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                "valueBoolean": true
+              }
+            ]
+          },
           "type": "group",
           "repeats": false
         },

--- a/fsh-generated/resources/Questionnaire-MedicalHistoryCurrentProblems.json
+++ b/fsh-generated/resources/Questionnaire-MedicalHistoryCurrentProblems.json
@@ -319,6 +319,15 @@
                 }
               ],
               "linkId": "92bd7d05-9b5e-4cf9-900b-703f361dad9d",
+              "text": "Medical history summary",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": true
             },
@@ -379,6 +388,15 @@
                 }
               ],
               "linkId": "newdiagnosis",
+              "text": "New diagnosis",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": true
             }

--- a/fsh-generated/resources/Questionnaire-PatientDetails.json
+++ b/fsh-generated/resources/Questionnaire-PatientDetails.json
@@ -551,6 +551,15 @@
                 }
               ],
               "linkId": "4e0dc185-f83e-4027-b7a8-ecb543d42c6d",
+              "text": "Home address",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": true,
               "enableWhen": [

--- a/fsh-generated/resources/Questionnaire-RegularMedications.json
+++ b/fsh-generated/resources/Questionnaire-RegularMedications.json
@@ -283,6 +283,15 @@
                 }
               ],
               "linkId": "regularmedications-summary-current",
+              "text": "Current medications",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": true
             },
@@ -301,6 +310,15 @@
                 }
               ],
               "linkId": "regularmedications-summary-new",
+              "text": "New medications",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": true,
               "item": [

--- a/fsh-generated/resources/Questionnaire-SubstanceUse.json
+++ b/fsh-generated/resources/Questionnaire-SubstanceUse.json
@@ -168,6 +168,15 @@
                 }
               ],
               "linkId": "substanceuse-smoking-smokingstatus",
+              "text": "Smoking status",
+              "_text": {
+                "extension": [
+                  {
+                    "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                    "valueBoolean": true
+                  }
+                ]
+              },
               "type": "group",
               "repeats": false
             },

--- a/input/fsh/715-Assessment-AbsoluteCVDRiskCalculation.fsh
+++ b/input/fsh/715-Assessment-AbsoluteCVDRiskCalculation.fsh
@@ -201,6 +201,10 @@ Description: "Absolute Cardiovascular Disease Risk Calculation sub-questionnaire
     * item[+]
       * extension[questionnaire-itemControl].valueCodeableConcept = http://hl7.org/fhir/questionnaire-item-control|1.0.0#grid
       * linkId = "fe9feec6-593a-4106-8a7d-f9965a632ea2"
+      * text = "Observation values"
+        * extension[+]
+          * url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+          * valueBoolean = true
       * type = #group 
       * repeats = false
       * item[+]

--- a/input/fsh/715-Assessment-AllergiesAdverseReactions.fsh
+++ b/input/fsh/715-Assessment-AllergiesAdverseReactions.fsh
@@ -131,6 +131,9 @@ Description: "Allergies/Adverse Reactions sub-questionnaire for Aboriginal and T
 * item[=].item[=].item[=].extension[TemplateExtractExtensionExtended][=].extension[resourceId][+].valueString = "item.where(linkId='allergyIntoleranceId').answer.value"
 * item[=].item[=].item[=].extension[TemplateExtractExtensionExtended][=].extension[type][+].valueCode = #AllergyIntolerance
 * item[=].item[=].item[=].linkId = "allergysummary"
+* item[=].item[=].item[=].text = "Adverse reaction risk summary"
+* item[=].item[=].item[=].text.extension[+].url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+* item[=].item[=].item[=].text.extension[=].valueBoolean = true
 * item[=].item[=].item[=].type = #group
 * item[=].item[=].item[=].repeats = true
 * item[=].item[=].item[=].item[0].extension[questionnaire-hidden].valueBoolean = true
@@ -185,6 +188,9 @@ Description: "Allergies/Adverse Reactions sub-questionnaire for Aboriginal and T
 * item[=].item[=].item[=].extension[=].extension.url = "template"
 * item[=].item[=].item[=].extension[=].extension.valueReference = Reference(AllergyIntoleranceTemplate)
 * item[=].item[=].item[=].linkId = "allergynew"
+* item[=].item[=].item[=].text = "New adverse reaction risks"
+* item[=].item[=].item[=].text.extension[+].url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+* item[=].item[=].item[=].text.extension[=].valueBoolean = true
 * item[=].item[=].item[=].type = #group
 * item[=].item[=].item[=].repeats = true
 * item[=].item[=].item[=].item[+].extension[+].url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"

--- a/input/fsh/715-Assessment-Examination.fsh
+++ b/input/fsh/715-Assessment-Examination.fsh
@@ -573,6 +573,10 @@ Description: "Examination sub-questionnaire for Aboriginal and Torres Strait Isl
       * expression = "%age > 12"
     * extension[questionnaire-itemControl].valueCodeableConcept = http://hl7.org/fhir/questionnaire-item-control|1.0.0#grid
     * linkId = "3639c586-9576-48d3-a52b-e91fd2138581"
+    * text = "Blood pressure"
+      * extension[+]
+        * url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+        * valueBoolean = true
     * type = #group
     * repeats = false
     * item[+]

--- a/input/fsh/715-Assessment-MedicalHistoryCurrentProblems.fsh
+++ b/input/fsh/715-Assessment-MedicalHistoryCurrentProblems.fsh
@@ -162,6 +162,10 @@ Description: "Medical History sub-questionnaire for Aboriginal and Torres Strait
         * extension[resourceId][+].valueString = "item.where(linkId='conditionId').answer.value"
         * extension[type][+].valueCode = #Condition
       * linkId = "92bd7d05-9b5e-4cf9-900b-703f361dad9d"
+      * text = "Medical history summary"
+        * extension[+]
+          * url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+          * valueBoolean = true
       * type = #group
       * repeats = true
       * item[+]
@@ -212,6 +216,10 @@ Description: "Medical History sub-questionnaire for Aboriginal and Torres Strait
       * extension[sdc-questionnaire-templateExtract]
         * extension[template].valueReference = Reference(ConditionTemplate)
       * linkId = "newdiagnosis"
+      * text = "New diagnosis"
+        * extension[+]
+          * url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+          * valueBoolean = true
       * type = #group
       * repeats = true
       * item[+]

--- a/input/fsh/715-Assessment-RegularMedications.fsh
+++ b/input/fsh/715-Assessment-RegularMedications.fsh
@@ -125,6 +125,9 @@ Description: "Regular Medications sub-questionnaire for Aboriginal and Torres St
 * item.item[=].item[=].extension[TemplateExtractExtensionExtended][=].extension[resourceId][+].valueString = "item.where(linkId='medicationStatementId').answer.value"
 * item.item[=].item[=].extension[TemplateExtractExtensionExtended][=].extension[type][+].valueCode = #MedicationStatement
 * item.item[=].item[=].linkId = "regularmedications-summary-current"
+* item.item[=].item[=].text = "Current medications"
+* item.item[=].item[=].text.extension[+].url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+* item.item[=].item[=].text.extension[=].valueBoolean = true
 * item.item[=].item[=].type = #group
 * item.item[=].item[=].repeats = true
 * item.item[=].item[=].item[0].extension[questionnaire-hidden].valueBoolean = true
@@ -238,6 +241,9 @@ Description: "Regular Medications sub-questionnaire for Aboriginal and Torres St
 * item.item[=].item[=].extension[=].extension.url = "template"
 * item.item[=].item[=].extension[=].extension.valueReference = Reference(MedicationStatementTemplate)
 * item.item[=].item[=].linkId = "regularmedications-summary-new"
+* item.item[=].item[=].text = "New medications"
+* item.item[=].item[=].text.extension[+].url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+* item.item[=].item[=].text.extension[=].valueBoolean = true
 * item.item[=].item[=].type = #group
 * item.item[=].item[=].repeats = true
 * item.item[=].item[=].item[+].extension[+].url = "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl"

--- a/input/fsh/715-Assessment-SubstanceUse.fsh
+++ b/input/fsh/715-Assessment-SubstanceUse.fsh
@@ -144,6 +144,10 @@ Description: "Substance Use sub-questionnaire for Aboriginal and Torres Strait I
     * item[+]
       * extension[questionnaire-itemControl].valueCodeableConcept = http://hl7.org/fhir/questionnaire-item-control|1.0.0#grid
       * linkId = "substanceuse-smoking-smokingstatus"
+      * text = "Smoking status"
+        * extension[+]
+          * url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+          * valueBoolean = true
       * type = #group
       * repeats = false
       * item[+]

--- a/input/fsh/715-PatientDetails.fsh
+++ b/input/fsh/715-PatientDetails.fsh
@@ -287,6 +287,10 @@ Description: "Patient Details sub-questionnaire for Aboriginal and Torres Strait
       * repeats = false
     * item[+]
       * linkId = "4e0dc185-f83e-4027-b7a8-ecb543d42c6d"
+      * text = "Home address"
+        * extension[+]
+          * url = "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden"
+          * valueBoolean = true
       * type = #group
       * repeats = true      
       * enableWhen[+]

--- a/input/resources/Questionnaire-AboriginalTorresStraitIslanderHealthCheck-assembled.json
+++ b/input/resources/Questionnaire-AboriginalTorresStraitIslanderHealthCheck-assembled.json
@@ -4928,6 +4928,15 @@
                                 },
                                 {
                                     "linkId": "4e0dc185-f83e-4027-b7a8-ecb543d42c6d",
+                                    "text": "Home Address",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "enableWhen": [
                                         {
@@ -6396,6 +6405,15 @@
                                         }
                                     ],
                                     "linkId": "92bd7d05-9b5e-4cf9-900b-703f361dad9d",
+                                    "text": "Medical history summary",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": true,
                                     "item": [
@@ -6526,6 +6544,15 @@
                                         }
                                     ],
                                     "linkId": "newdiagnosis",
+                                    "text": "New Diagnosis",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": true,
                                     "item": [
@@ -6723,6 +6750,15 @@
                                         }
                                     ],
                                     "linkId": "regularmedications-summary-current",
+                                    "text": "Current regular medications",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": true,
                                     "item": [
@@ -6891,6 +6927,15 @@
                                         }
                                     ],
                                     "linkId": "regularmedications-summary-new",
+                                    "text": "New regular medications",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": true,
                                     "item": [
@@ -7204,6 +7249,15 @@
                                         }
                                     ],
                                     "linkId": "allergysummary",
+                                    "text": "Adverse reaction risk summary",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": true,
                                     "item": [
@@ -7354,6 +7408,15 @@
                                         }
                                     ],
                                     "linkId": "allergynew",
+                                    "text": "New allergy",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": true,
                                     "item": [
@@ -12316,6 +12379,15 @@
                                         }
                                     ],
                                     "linkId": "substanceuse-smoking-smokingstatus",
+                                    "text": "Smoking status",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": false,
                                     "item": [
@@ -16098,6 +16170,15 @@
                                 }
                             ],
                             "linkId": "3639c586-9576-48d3-a52b-e91fd2138581",
+                            "text": "Blood pressure",
+                            "_text": {
+                                "extension": [
+                                    {
+                                        "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
                             "type": "group",
                             "repeats": false,
                             "item": [
@@ -16556,6 +16637,15 @@
                                         }
                                     ],
                                     "linkId": "fe9feec6-593a-4106-8a7d-f9965a632ea2",
+                                    "text": "Blood pressure",
+                                    "_text": {
+                                        "extension": [
+                                            {
+                                                "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
+                                                "valueBoolean": true
+                                            }
+                                        ]
+                                    },
                                     "type": "group",
                                     "repeats": false,
                                     "item": [

--- a/input/resources/Questionnaire-AboriginalTorresStraitIslanderHealthCheck-assembled.json
+++ b/input/resources/Questionnaire-AboriginalTorresStraitIslanderHealthCheck-assembled.json
@@ -4928,7 +4928,7 @@
                                 },
                                 {
                                     "linkId": "4e0dc185-f83e-4027-b7a8-ecb543d42c6d",
-                                    "text": "Home Address",
+                                    "text": "Home address",
                                     "_text": {
                                         "extension": [
                                             {
@@ -6544,7 +6544,7 @@
                                         }
                                     ],
                                     "linkId": "newdiagnosis",
-                                    "text": "New Diagnosis",
+                                    "text": "New diagnosis",
                                     "_text": {
                                         "extension": [
                                             {
@@ -6750,7 +6750,7 @@
                                         }
                                     ],
                                     "linkId": "regularmedications-summary-current",
-                                    "text": "Current regular medications",
+                                    "text": "Current medications",
                                     "_text": {
                                         "extension": [
                                             {
@@ -6927,7 +6927,7 @@
                                         }
                                     ],
                                     "linkId": "regularmedications-summary-new",
-                                    "text": "New regular medications",
+                                    "text": "New medications",
                                     "_text": {
                                         "extension": [
                                             {
@@ -7408,7 +7408,7 @@
                                         }
                                     ],
                                     "linkId": "allergynew",
-                                    "text": "New allergy",
+                                    "text": "New adverse reaction risks",
                                     "_text": {
                                         "extension": [
                                             {
@@ -16637,7 +16637,7 @@
                                         }
                                     ],
                                     "linkId": "fe9feec6-593a-4106-8a7d-f9965a632ea2",
-                                    "text": "Blood pressure",
+                                    "text": "Observation values",
                                     "_text": {
                                         "extension": [
                                             {


### PR DESCRIPTION
Refer to https://github.com/aehrc/smart-forms/issues/1367. Only affects in-form rendering.

Extension is defined at the "_text" as an extension:
```
"_text": {
    "extension": [
        {
            "url": "https://smartforms.csiro.au/docs/custom-extension/questionnaire-item-text-hidden",
            "valueBoolean": true
        }
    ]
},
```

Changes not done for FSH. @liambarnes can you replicate these changes in FSH subquestionnaires?